### PR TITLE
Shuffle PHP versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "codeigniter/coding-standard": "^1.1",
         "fakerphp/faker": "^1.9",
         "mikey179/vfsstream": "^1.6",
@@ -34,15 +34,6 @@
         "phpunit/phpunit": "^9.3",
         "roave/security-advisories": "dev-latest"
     },
-    "require-dev": {
-        "codeigniter4/codeigniter4": "dev-develop"
-    },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/codeigniter4/CodeIgniter4"
-        }
-    ],
     "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/src/.github/workflows/phpcsfixer.yml
+++ b/src/.github/workflows/phpcsfixer.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.3', '7.4', '8.0']
+        php-versions: ['7.4', '8.0', '8.1']
 
     steps:
       - name: Checkout

--- a/src/.github/workflows/phpstan.yml
+++ b/src/.github/workflows/phpstan.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.3', '7.4', '8.0']
+        php-versions: ['7.4', '8.0', '8.1']
 
     steps:
       - name: Checkout

--- a/src/.github/workflows/phpunit.yml
+++ b/src/.github/workflows/phpunit.yml
@@ -25,7 +25,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0']
+        php-versions: ['7.4', '8.0', '8.1']
 
     steps:
       - name: Checkout

--- a/src/.github/workflows/rector.yml
+++ b/src/.github/workflows/rector.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.3', '7.4', '8.0']
+        php-versions: ['7.4', '8.0', '8.1']
 
     steps:
       - name: Checkout

--- a/src/phpunit.xml.dist
+++ b/src/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+		xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
 		bootstrap="vendor/codeigniter4/framework/system/Test/bootstrap.php"
 		backupGlobals="false"
 		beStrictAboutCoversAnnotation="true"

--- a/src/rector.php
+++ b/src/rector.php
@@ -38,7 +38,7 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 return static function (ContainerConfigurator $containerConfigurator): void {
     // Rule sets to apply
     $containerConfigurator->import(SetList::DEAD_CODE);
-    $containerConfigurator->import(LevelSetList::UP_TO_PHP_73);
+    $containerConfigurator->import(LevelSetList::UP_TO_PHP_74);
     $containerConfigurator->import(PHPUnitSetList::PHPUNIT_SPECIFIC_METHOD);
     $containerConfigurator->import(PHPUnitSetList::PHPUNIT_80);
 


### PR DESCRIPTION
* Drops support for PHP 7.4 (to stay consistent with upcoming framework changes)
* Adds PHP 8.1 to workflow matrices