### PR TITLE
Standardize paths

### DIFF
--- a/src/Template/.github/workflows/phpcpd.yml
+++ b/src/Template/.github/workflows/phpcpd.yml
@@ -33,4 +33,4 @@ jobs:
           coverage: none
 
       - name: Detect duplicate code
-        run: phpcpd app/ src/ tests/
+        run: phpcpd app/ tests/

--- a/src/Template/.php-cs-fixer.dist.php
+++ b/src/Template/.php-cs-fixer.dist.php
@@ -7,8 +7,8 @@ use PhpCsFixer\Finder;
 $finder = Finder::create()
     ->files()
     ->in([
-        __DIR__ . '/app',
-        __DIR__ . '/tests',
+        __DIR__ . '/app/',
+        __DIR__ . '/tests/',
     ])
     ->exclude('build')
     ->append([__FILE__]);

--- a/src/Template/depfile.yaml
+++ b/src/Template/depfile.yaml
@@ -1,5 +1,5 @@
 paths:
-  - ./app
+  - ./app/
   - ./vendor/codeigniter4/framework/system
 exclude_files:
   - '#.*test.*#i'

--- a/src/Template/phpstan.neon.dist
+++ b/src/Template/phpstan.neon.dist
@@ -7,8 +7,8 @@ parameters:
 	bootstrapFiles:
 		- vendor/codeigniter4/framework/system/Test/bootstrap.php
 	excludePaths:
-		- src/Config/Routes.php
-		- src/Views/*
+		- app/Config/Routes.php
+		- app/Views/*
 	ignoreErrors:
 		- '#Call to an undefined static method Config\\Services::[A-Za-z]+\(\)#'
 	universalObjectCratesClasses:

--- a/src/Template/phpunit.xml.dist
+++ b/src/Template/phpunit.xml.dist
@@ -21,7 +21,7 @@
 
 	<coverage includeUncoveredFiles="true" processUncoveredFiles="true">
 		<include>
-			<directory suffix=".php">./app</directory>
+			<directory suffix=".php">./app/</directory>
 		</include>
 		<exclude>
 			<directory suffix=".php">./app/Config</directory>

--- a/src/Template/rector.php
+++ b/src/Template/rector.php
@@ -47,8 +47,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set(Option::PARALLEL, true);
     // The paths to refactor (can also be supplied with CLI arguments)
     $parameters->set(Option::PATHS, [
-        __DIR__ . '/app',
-        __DIR__ . '/tests',
+        __DIR__ . '/app/',
+        __DIR__ . '/tests/',
     ]);
 
     // Do you need to include constants, class aliases, or a custom autoloader?


### PR DESCRIPTION
I am working on an automated conversion of the various template files to be able to apply them to libraries (where source code is in **src/** instead of **app/**). To facilitate this "search and replace" (and avoid matching things like "**app**end()") I'm adding trailing slashes everywhere that the string "app" is actually a directory reference.