### PR TITLE
Strip GitHub Authentication

### DIFF
--- a/src/Template/.github/workflows/deptrac.yml
+++ b/src/Template/.github/workflows/deptrac.yml
@@ -61,7 +61,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer -q config -g github-oauth.github.com "${{ secrets.GITHUB_TOKEN }}"
           if [ -f composer.lock ]; then
             composer install --no-progress --no-interaction --prefer-dist --optimize-autoloader
           else

--- a/src/Template/.github/workflows/infection.yml
+++ b/src/Template/.github/workflows/infection.yml
@@ -57,7 +57,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer -q config -g github-oauth.github.com "${{ secrets.GITHUB_TOKEN }}"
           if [ -f composer.lock ]; then
             composer install --no-progress --no-interaction --prefer-dist --optimize-autoloader
           else

--- a/src/Template/.github/workflows/phpcsfixer.yml
+++ b/src/Template/.github/workflows/phpcsfixer.yml
@@ -50,7 +50,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer -q config -g github-oauth.github.com "${{ secrets.GITHUB_TOKEN }}"
           if [ -f composer.lock ]; then
             composer install --no-progress --no-interaction --prefer-dist --optimize-autoloader
           else

--- a/src/Template/.github/workflows/phpstan.yml
+++ b/src/Template/.github/workflows/phpstan.yml
@@ -65,7 +65,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer -q config -g github-oauth.github.com "${{ secrets.GITHUB_TOKEN }}"
           if [ -f composer.lock ]; then
             composer install --no-progress --no-interaction --prefer-dist --optimize-autoloader
           else

--- a/src/Template/.github/workflows/phpunit.yml
+++ b/src/Template/.github/workflows/phpunit.yml
@@ -54,7 +54,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer -q config -g github-oauth.github.com "${{ secrets.GITHUB_TOKEN }}"
           if [ -f composer.lock ]; then
             composer install --no-progress --no-interaction --prefer-dist --optimize-autoloader
           else

--- a/src/Template/.github/workflows/rector.yml
+++ b/src/Template/.github/workflows/rector.yml
@@ -55,7 +55,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer -q config -g github-oauth.github.com "${{ secrets.GITHUB_TOKEN }}"
           if [ -f composer.lock ]; then
             composer install --no-progress --no-interaction --prefer-dist --optimize-autoloader
           else

--- a/src/Template/.github/workflows/unused.yml
+++ b/src/Template/.github/workflows/unused.yml
@@ -49,7 +49,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer -q config -g github-oauth.github.com "${{ secrets.GITHUB_TOKEN }}"
           if [ -f composer.lock ]; then
             composer install --no-progress --no-interaction --prefer-dist --optimize-autoloader
           else


### PR DESCRIPTION
GitHub Auth errors used to be pretty rare but now they seem to happen all the time. I've never been able to figure out why - my guess is some sort of race condition with the Actions token?

This PR removes authentication from Composer which should work fine but will subject Actions to the "unauthenticated API limits".