### PR TITLE
Rector Version

### DIFF
--- a/src/Template/.github/workflows/rector.yml
+++ b/src/Template/.github/workflows/rector.yml
@@ -63,5 +63,5 @@ jobs:
 
       - name: Analyze for refactoring
         run: |
-          composer global require --dev rector/rector:^0.12.16
+          composer global require --dev rector/rector:^0.13.8
           rector process --dry-run --no-progress-bar


### PR DESCRIPTION
Since Rector is still `< 1.0` the minor version actually controls the update behavior of `^`. This moves to the `0.13` series in the Actions template.