### PR TITLE
Add Directory Check

### DIFF
--- a/src/Template/psalm_autoload.php
+++ b/src/Template/psalm_autoload.php
@@ -10,6 +10,10 @@ $helperDirs = [
 ];
 
 foreach ($helperDirs as $dir) {
+    if (! is_dir($dir)) {
+        continue;
+    }
+
     $dir = __DIR__ . '/' . $dir;
     chdir($dir);
 


### PR DESCRIPTION
Prevents failures during **psalm_autoload.php** if any of the directories don't exist.