### PR TITLE
Indicate Composer Dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "devkit",
         "toolkit",
         "development",
-        "tools"
+        "tools",
+        "static analysis"
     ],
     "authors": [
         {


### PR DESCRIPTION
Takes advantage of the new Composer feature to identify packages as "development libraries" based on the "static analysis" keyword.

See https://github.com/CodeIgniter/coding-standard/pull/2