### PR TITLE
chore: update infection.yml

### DIFF
--- a/src/Template/.github/workflows/infection.yml
+++ b/src/Template/.github/workflows/infection.yml
@@ -9,14 +9,6 @@ on:
       - 'composer.*'
       - 'phpunit*'
       - '.github/workflows/infection.yml'
-  push:
-    branches:
-      - develop
-    paths:
-      - '**.php'
-      - 'composer.*'
-      - 'phpunit*'
-      - '.github/workflows/infection.yml'
 
 jobs:
   main:
@@ -62,10 +54,7 @@ jobs:
             composer update --no-progress --no-interaction --prefer-dist --optimize-autoloader
           fi
 
-      - name: Test with PHPUnit
-        run: vendor/bin/phpunit --teamcity
-
-      - name: Mutate with Infection
+      - name: Run Infection for added files only
         run: |
           git fetch --depth=1 origin $GITHUB_BASE_REF
-          infection --threads=2 --skip-initial-tests --coverage=build/phpunit --git-diff-base=origin/$GITHUB_BASE_REF --git-diff-filter=AM --logger-github --ignore-msi-with-no-mutations
+          infection --threads=max --git-diff-lines --git-diff-base=origin/$GITHUB_BASE_REF --ignore-msi-with-no-mutations --only-covered --logger-github


### PR DESCRIPTION
- `$GITHUB_BASE_REF` does not work with pushes.
- Ref: https://github.com/infection/infection/blob/30c91e6300932b048d7434a90d85583fde37eb6b/.github/workflows/mt-annotations.yaml#L52-L55

See https://github.com/codeigniter4/tasks/pull/107