### PR TITLE
Update nexusphp/tachycardia to ^1.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "fakerphp/faker": "^1.9",
         "mikey179/vfsstream": "^1.6",
         "nexusphp/cs-config": "^3.6",
-        "nexusphp/tachycardia": "^1.0",
+        "nexusphp/tachycardia": "^1.3",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan": "^1.0",
         "phpstan/phpstan-deprecation-rules": "^1.0",


### PR DESCRIPTION
Expeditable trait was introduced in [v1.3.0](https://github.com/NexusPHP/tachycardia/releases/tag/v1.3.0). 
codeigniter4/settings use it.

See https://github.com/codeigniter4/settings/pull/95
```
phpunit / PHP 7.4 - MySQLi - lowest

...

Run vendor/bin/phpunit --verbose --coverage-text --testsuite main
PHP Fatal error:  Trait 'Nexus\PHPUnit\Extension\Expeditable' not found in /home/runner/work/settings/settings/tests/_support/TestCase.php on line 11

Fatal error: Trait 'Nexus\PHPUnit\Extension\Expeditable' not found in /home/runner/work/settings/settings/tests/_support/TestCase.php on line 11
Error: Process completed with exit code 255.
```
https://github.com/codeigniter4/settings/actions/runs/6104148667/job/16565731540?pr=95