### PR TITLE
chore: move rector from `require-dev` to `require`

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,8 @@ predefined rulesets. Rector can be highly opinionated based on its configuration
 so be sure to read the documentation and figure out the best fit for you. This workflow performs
 a "dry run" to check for any changes that Rector would have made and fail if there are matches.
 
-> Note: Rector updates rules all the time, so you may want to lock your repo to
+> **Note**
+> Rector updates rules all the time, so you may want to lock your repo to
 > the latest known working version of Rector to prevent unexpected failures.
 > Using pinned version in `composer.json` and update it with dependabot is the
 > best practice.

--- a/composer.json
+++ b/composer.json
@@ -34,12 +34,12 @@
         "phpstan/phpstan-phpunit": "^1.0",
         "phpunit/phpunit": "^9.3",
         "roave/security-advisories": "dev-latest",
-        "vimeo/psalm": "^5.0"
+        "vimeo/psalm": "^5.0",
+        "rector/rector": "^0.18.3"
     },
     "require-dev": {
         "codeigniter4/framework": "^4.1",
-        "icanhazstring/composer-unused": "^0.8.2",
-        "rector/rector": "0.18.3"
+        "icanhazstring/composer-unused": "^0.8.2"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
**Description**
See https://github.com/codeigniter4/devkit/pull/111#issuecomment-1712987977

**Checklist:**
- [x] Securely signed commits
- [] Component(s) with PHPDoc blocks, only if necessary or adds value
- [] Unit testing, with >80% coverage
- [] User guide updated
- [] Conforms to style guide
