### PR TITLE
Update dependencies - PHP 8.1 - 8.4

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.4', '8.0', '8.1']
+        php-versions: ['8.1', '8.2', '8.3', '8.4']
 
     steps:
       - name: Checkout

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.4', '8.0', '8.1']
+        php-versions: ['8.1', '8.2', '8.3', '8.4']
 
     steps:
       - name: Checkout

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,129 @@
-vendor/
-build/
-phpunit*.xml
-phpunit
-*.cache
-composer.lock
+#-------------------------
+# Operating Specific Junk Files
+#-------------------------
+
+# OS X
 .DS_Store
+.AppleDouble
+.LSOverride
+
+# OS X Thumbnails
+._*
+
+# Windows image file caches
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# Linux
+*~
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+#-------------------------
+# Environment Files
+#-------------------------
+# These should never be under version control,
+# as it poses a security risk.
+.env
+.vagrant
+Vagrantfile
+
+#-------------------------
+# Temporary Files
+#-------------------------
+writable/cache/*
+!writable/cache/index.html
+
+writable/logs/*
+!writable/logs/index.html
+
+writable/session/*
+!writable/session/index.html
+
+writable/uploads/*
+!writable/uploads/index.html
+
+writable/debugbar/*
+!writable/debugbar/index.html
+
+writable/**/*.db
+writable/**/*.sqlite
+
+php_errors.log
+
+#-------------------------
+# User Guide Temp Files
+#-------------------------
+user_guide_src/build/*
+
+#-------------------------
+# Test Files
+#-------------------------
+tests/coverage*
+
+# Don't save phpunit under version control.
+phpunit
+
+#-------------------------
+# Composer
+#-------------------------
+vendor/
+composer.lock
+
+#-------------------------
+# IDE / Development Files
+#-------------------------
+
+# Modules Testing
+_modules/*
+
+# phpenv local config
+.php-version
+
+# Jetbrains editors (PHPStorm, etc)
+.idea/
+*.iml
+
+# Netbeans
+nbproject/
+build/
+nbbuild/
+dist/
+nbdist/
+nbactions.xml
+nb-configuration.xml
+.nb-gradle/
+
+# Sublime Text
+*.tmlanguage.cache
+*.tmPreferences.cache
+*.stTheme.cache
+*.sublime-workspace
+*.sublime-project
+.phpintel
+/api/
+
+# Visual Studio Code
+.vscode/
+
+/results/
+/phpunit*.xml
+
+/.php-cs-fixer.php

--- a/composer.json
+++ b/composer.json
@@ -22,24 +22,24 @@
     ],
     "homepage": "https://github.com/codeigniter4/devkit",
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "codeigniter/coding-standard": "^1.5",
         "fakerphp/faker": "^1.9",
         "mikey179/vfsstream": "^1.6",
         "nexusphp/cs-config": "^3.6",
-        "nexusphp/tachycardia": "^1.3 || ^2.0",
+        "nexusphp/tachycardia": "^2.0",
         "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan": "^1.0",
-        "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpstan/phpstan-phpunit": "^1.0",
-        "phpunit/phpunit": "^9.3 || ^10.5.16",
-        "rector/rector": "^0.19 || ^1.0.0",
+        "phpstan/phpstan": "^2.0",
+        "phpstan/phpstan-deprecation-rules": "^2.0",
+        "phpstan/phpstan-phpunit": "^2.0",
+        "phpunit/phpunit": "^10.5 || ^11.5",
+        "rector/rector": "^2.0",
         "roave/security-advisories": "dev-latest",
         "vimeo/psalm": "^5.0"
     },
     "require-dev": {
         "codeigniter4/framework": "^4.1",
-        "icanhazstring/composer-unused": "^0.8.2"
+        "icanhazstring/composer-unused": "dev-main"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "phpunit/phpunit": "^10.5 || ^11.5",
         "rector/rector": "^2.0",
         "roave/security-advisories": "dev-latest",
-        "vimeo/psalm": "^5.0"
+        "vimeo/psalm": "^6.0"
     },
     "require-dev": {
         "codeigniter4/framework": "^4.1",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,8 +6,7 @@ parameters:
 	bootstrapFiles:
 		- vendor/codeigniter4/framework/system/Test/bootstrap.php
 	excludePaths:
-		- src/Config/Routes.php
-		- src/Views/*
+		- src/docker/*
 	ignoreErrors:
 	universalObjectCratesClasses:
 		- CodeIgniter\Entity

--- a/src/Template/.github/workflows/infection.yml
+++ b/src/Template/.github/workflows/infection.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           tools: infection, phpunit
           extensions: intl, json, mbstring, gd, xml, sqlite3
           coverage: xdebug

--- a/src/Template/.github/workflows/phpstan.yml
+++ b/src/Template/.github/workflows/phpstan.yml
@@ -64,15 +64,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          OPTIONS='--no-progress --no-interaction --prefer-dist --optimize-autoloader'
-          if [[ '${{ matrix.php-versions }}' == '8.4' ]]; then
-            OPTIONS="$OPTIONS --ignore-platform-reqs"
-          fi
-
           if [ -f composer.lock ]; then
-            composer install $OPTIONS
+            composer install --no-progress --no-interaction --prefer-dist --optimize-autoloader
           else
-            composer update $OPTIONS
+            composer update --no-progress --no-interaction --prefer-dist --optimize-autoloader
           fi
 
       - name: Run static analysis

--- a/src/Template/.github/workflows/phpstan.yml
+++ b/src/Template/.github/workflows/phpstan.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.4', '8.0', '8.1', '8.2']
+        php-versions: ['8.1', '8.2', '8.3', '8.4']
 
     steps:
       - name: Checkout
@@ -64,10 +64,15 @@ jobs:
 
       - name: Install dependencies
         run: |
+          OPTIONS='--no-progress --no-interaction --prefer-dist --optimize-autoloader'
+          if [[ '${{ matrix.php-versions }}' == '8.4' ]]; then
+            OPTIONS="$OPTIONS --ignore-platform-reqs"
+          fi
+
           if [ -f composer.lock ]; then
-            composer install --no-progress --no-interaction --prefer-dist --optimize-autoloader
+            composer install $OPTIONS
           else
-            composer update --no-progress --no-interaction --prefer-dist --optimize-autoloader
+            composer update $OPTIONS
           fi
 
       - name: Run static analysis

--- a/src/Template/.github/workflows/phpunit.yml
+++ b/src/Template/.github/workflows/phpunit.yml
@@ -53,15 +53,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          OPTIONS="${{ env.COMPOSER_UPDATE_FLAGS }} --no-progress --no-interaction --prefer-dist --optimize-autoloader"
-          if [[ '${{ matrix.php-versions }}' == '8.4' ]]; then
-            OPTIONS="$OPTIONS --ignore-platform-reqs"
-          fi
-
           if [ -f composer.lock ]; then
-            composer install $OPTIONS
+            composer install --no-progress --no-interaction --prefer-dist --optimize-autoloader
           else
-            composer update $OPTIONS
+            composer update --no-progress --no-interaction --prefer-dist --optimize-autoloader
           fi
 
       - name: Test with PHPUnit

--- a/src/Template/.github/workflows/phpunit.yml
+++ b/src/Template/.github/workflows/phpunit.yml
@@ -25,7 +25,7 @@ jobs:
     if: (! contains(github.event.head_commit.message, '[ci skip]'))
     strategy:
       matrix:
-        php-versions: ['7.4', '8.0', '8.1', '8.2']
+        php-versions: ['8.1', '8.2', '8.3', '8.4']
 
     steps:
       - name: Checkout
@@ -53,10 +53,15 @@ jobs:
 
       - name: Install dependencies
         run: |
+          OPTIONS="${{ env.COMPOSER_UPDATE_FLAGS }} --no-progress --no-interaction --prefer-dist --optimize-autoloader"
+          if [[ '${{ matrix.php-versions }}' == '8.4' ]]; then
+            OPTIONS="$OPTIONS --ignore-platform-reqs"
+          fi
+
           if [ -f composer.lock ]; then
-            composer install --no-progress --no-interaction --prefer-dist --optimize-autoloader
+            composer install $OPTIONS
           else
-            composer update --no-progress --no-interaction --prefer-dist --optimize-autoloader
+            composer update $OPTIONS
           fi
 
       - name: Test with PHPUnit

--- a/src/Template/.github/workflows/rector.yml
+++ b/src/Template/.github/workflows/rector.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.4', '8.0', '8.1', '8.2']
+        php-versions: ['8.1', '8.2', '8.3', '8.4']
 
     steps:
       - name: Checkout
@@ -54,10 +54,15 @@ jobs:
 
       - name: Install dependencies
         run: |
+          OPTIONS='--no-progress --no-interaction --prefer-dist --optimize-autoloader'
+          if [[ '${{ matrix.php-versions }}' == '8.4' ]]; then
+            OPTIONS="$OPTIONS --ignore-platform-reqs"
+          fi
+
           if [ -f composer.lock ]; then
-            composer install --no-progress --no-interaction --prefer-dist --optimize-autoloader
+            composer install $OPTIONS
           else
-            composer update --no-progress --no-interaction --prefer-dist --optimize-autoloader
+            composer update $OPTIONS
           fi
 
       - name: Rector Cache

--- a/src/Template/.github/workflows/rector.yml
+++ b/src/Template/.github/workflows/rector.yml
@@ -54,15 +54,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          OPTIONS='--no-progress --no-interaction --prefer-dist --optimize-autoloader'
-          if [[ '${{ matrix.php-versions }}' == '8.4' ]]; then
-            OPTIONS="$OPTIONS --ignore-platform-reqs"
-          fi
-
           if [ -f composer.lock ]; then
-            composer install $OPTIONS
+            composer install --no-progress --no-interaction --prefer-dist --optimize-autoloader
           else
-            composer update $OPTIONS
+            composer update --no-progress --no-interaction --prefer-dist --optimize-autoloader
           fi
 
       - name: Rector Cache

--- a/src/Template/phpunit.xml.dist
+++ b/src/Template/phpunit.xml.dist
@@ -12,7 +12,7 @@
     stopOnFailure="false"
     stopOnIncomplete="false"
     stopOnSkipped="false"
-    cacheDirectory=".phpunit.cache"
+    cacheDirectory="build/.phpunit.cache"
     beStrictAboutCoverageMetadata="true">
     <coverage includeUncoveredFiles="true">
         <report>

--- a/src/Template/rector.php
+++ b/src/Template/rector.php
@@ -47,7 +47,7 @@ use Rector\ValueObject\PhpVersion;
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([
         SetList::DEAD_CODE,
-        LevelSetList::UP_TO_PHP_74,
+        LevelSetList::UP_TO_PHP_81,
         PHPUnitSetList::PHPUNIT_CODE_QUALITY,
         PHPUnitSetList::PHPUNIT_100,
     ]);
@@ -81,7 +81,7 @@ return static function (RectorConfig $rectorConfig): void {
     }
 
     // Set the target version for refactoring
-    $rectorConfig->phpVersion(PhpVersion::PHP_74);
+    $rectorConfig->phpVersion(PhpVersion::PHP_81);
 
     // Auto-import fully qualified class names
     $rectorConfig->importNames();


### PR DESCRIPTION
**Description**
This PR updates dependencies for use only with currently supported versions of PHP (8.1 - 8.4).

~~We still need to call composer with the `--ignore-platform-reqs` flag for PHP 8.4, as Psalm does not support it yet.~~

Changes:
* PHP 8.1 as a minimum version in composer
* Rector template with the target PHP version set to 8.1
* PHPUnit, PHPStan, and Rector workflow templates with updated PHP versions

These changes should allow us to use devkit for projects that use PHP 8.4.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
