### PR TITLE
Psalm - disable `ensureOverrideAttribute` config item

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -9,6 +9,7 @@
     cacheDirectory="build/psalm/"
     findUnusedBaselineEntry="true"
     findUnusedCode="false"
+    ensureOverrideAttribute="false"
 >
     <projectFiles>
         <directory name="src/" />


### PR DESCRIPTION
**Description**
This PR disables the `ensureOverrideAttribute` config item. Before, this was disabled by default, but changes in the recent release made this config enabled by default.

I'm open to discussing whether we should go with the default settings or disable it.

Details: https://psalm.dev/docs/running_psalm/issues/MissingOverrideAttribute/

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
