### PR TITLE
update deptrac template for deptrac/deptrac

### DIFF
--- a/src/Template/deptrac.yaml
+++ b/src/Template/deptrac.yaml
@@ -1,4 +1,4 @@
-parameters:
+deptrac:
   paths:
     - ./app/
     - ./vendor/codeigniter4/framework/system/
@@ -153,4 +153,4 @@ parameters:
       - Vendor Entity
       - Vendor Model
       - Vendor View
-  skip_violations:
+  skip_violations: []


### PR DESCRIPTION
**Description**
This PR updates deptrac.yaml template for `deptrac/deptrac`

This is my mistake. I copied the template from a project where I used `qossmic/deptrac` instead of `deptrac/deptrac` (newer release). From here on, I applied this template to other repos.

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
