### PR TITLE
update infection template

### DIFF
--- a/src/Template/.github/workflows/infection.yml
+++ b/src/Template/.github/workflows/infection.yml
@@ -57,4 +57,4 @@ jobs:
       - name: Run Infection for added files only
         run: |
           git fetch --depth=1 origin $GITHUB_BASE_REF
-          infection --threads=max --git-diff-lines --git-diff-base=origin/$GITHUB_BASE_REF --ignore-msi-with-no-mutations --logger-github
+          infection --threads=max --git-diff-lines --git-diff-base=origin/$GITHUB_BASE_REF --ignore-msi-with-no-mutations

--- a/src/Template/.github/workflows/infection.yml
+++ b/src/Template/.github/workflows/infection.yml
@@ -57,4 +57,4 @@ jobs:
       - name: Run Infection for added files only
         run: |
           git fetch --depth=1 origin $GITHUB_BASE_REF
-          infection --threads=max --git-diff-lines --git-diff-base=origin/$GITHUB_BASE_REF --ignore-msi-with-no-mutations --only-covered --logger-github
+          infection --threads=max --git-diff-lines --git-diff-base=origin/$GITHUB_BASE_REF --ignore-msi-with-no-mutations --logger-github


### PR DESCRIPTION
**Description**
The `--only-covered` flag was removed in Infection 0.31.0, see: https://infection.github.io/guide/command-line-options.html#only-covered

Failed action as a reference: https://github.com/codeigniter4projects/website/actions/runs/16732695219/job/47364306883

**Checklist:**
- [x] Securely signed commits
- [ ] Component(s) with PHPDoc blocks, only if necessary or adds value
- [ ] Unit testing, with >80% coverage
- [ ] User guide updated
- [ ] Conforms to style guide
